### PR TITLE
Evaluate Environmental Product Declaration method

### DIFF
--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.LifeCycleAssessment
         /***************************************************/
 
         [Description("This method calculates the quantity of any selected metric within an Environmental Product Declaration by extracting the declared unit of the selected material and multiplying the objects Volume * Density * EnvironmentalProductDeclarationField criteria. Please view the EnvironmentalProductDeclarationField Enum to explore current evaluation metric options.")]
-        [Input("BHoM Object", "This is a BHoM Object to calculate EPD off of. The method requires a volume property on the BHoM Object. Density is required if the chosen EPD is on a per mass basis, and will be extracted from the dataset if possible prior to extracting from the object itself.")]
+        [Input("obj", "This is a BHoM Object to calculate EPD off of. The method requires a volume property on the BHoM Object. Density is required if the chosen EPD is on a per mass basis, and will be extracted from the dataset if possible prior to extracting from the object itself.")]
         [Input("environmentalProductDeclaration", "This is LifeCycleAssessment.EnvironmentalProductDeclaration data. Please select your desired dataset and supply your material choice to the corresponding BHoM objects.")]
         [Input("environmentalProductDeclarationField", "Filter the provided EnvironmentalProductDeclaration by selecting one of the provided metrics for calculation. This method also accepts multiple fields simultaneously.")]
         [Output("quantity", "The quantity of the desired metric provided by the EnvironmentalProductDeclarationField")]

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.LifeCycleAssessment
         [Input("environmentalProductDeclaration", "This is LifeCycleAssessment.EnvironmentalProductDeclaration data. Please select your desired dataset and supply your material choice to the corresponding BHoM objects.")]
         [Input("environmentalProductDeclarationField", "Filter the provided EnvironmentalProductDeclaration by selecting one of the provided metrics for calculation. This method also accepts multiple fields simultaneously.")]
         [Output("quantity", "The quantity of the desired metric provided by the EnvironmentalProductDeclarationField")]
-        public static double EvaluateEnvironmentalProductDeclarationPerObject(IBHoMObject obj = null, EnvironmentalProductDeclaration environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential) //default to globalWarmingPotential evaluation
+        public static double EvaluateEnvironmentalProductDeclarationPerObject(IBHoMObject obj, EnvironmentalProductDeclaration environmentalProductDeclaration, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential) //default to globalWarmingPotential evaluation
         {
             if (obj != null)
             {
@@ -73,9 +73,11 @@ namespace BH.Engine.LifeCycleAssessment
                 else if (declaredUnitType == "Mass")
                 {
                     double density = 0;
-                    if (System.Convert.ToDouble(environmentalProductDeclaration.Density) != 0)
+                    string epdDensity = environmentalProductDeclaration.Density.ToString() ?? "";
+                    double densityVal = System.Convert.ToDouble(epdDensity.Substring(0, epdDensity.IndexOf(" ")));
+                    if (System.Convert.ToDouble(densityVal) != 0)
                     {
-                        density = System.Convert.ToDouble(environmentalProductDeclaration.Density);
+                        density = densityVal;
                         BH.Engine.Reflection.Compute.RecordNote(String.Format("This method is using a density of {0} supplied by the EnvironmentalProductDeclaration to calculate Mass.", density));
                     }
                     else if (obj.PropertyValue("Density") == null)

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
@@ -1,0 +1,223 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+//using BH.oM.Structure; <--This was used for IMass calc. Remove when IelementM is implemented.
+using System.ComponentModel;
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using BH.oM.LifeCycleAssessment;
+
+namespace BH.Engine.LifeCycleAssessment
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****   Public Methods                          ****/
+        /***************************************************/
+
+        [Description("This method calculates the quantity of any selected metric within an Environmental Product Declaration by extracting the declared unit of the selected material and multiplying the objects Volume * Density * EnvironmentalProductDeclarationField criteria. Please view the EnvironmentalProductDeclarationField Enum to explore current evaluation metric options.")]
+        [Input("BHoM CustomObject", "This is a BHoM CustomObject made with CreateCustom. The method expects Volume and Density properties. Density will be extracted from the dataset if possible prior to extracting from the object itself.")]
+        [Input("environmentalProductDeclaration", "This is LifeCycleAssessment.EnvironmentalProductDeclaration data. Please select your desired dataset and supply your material choice to the corresponding BHoM objects.")]
+        [Input("environmentalProductDeclarationField", "Filter the provided EnvironmentalProductDeclaration by selecting one of the provided metrics for calculation. This method also accepts multiple fields simultaneously.")]
+        [Output("quantity", "The quantity of the desired metric provided by the EnvironmentalProductDeclarationField")]
+        public static double EvaluateEnvironmentalProductDeclaration(CustomObject obj = null, EnvironmentalProductDeclaration environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential) //default to globalWarmingPotential evaluation
+        {
+            if (obj != null)
+            {
+                //if declared unit from EnvironmentalProductDeclaration is kg (standard unit).
+                if (environmentalProductDeclaration.DeclaredUnit != null && environmentalProductDeclaration.DeclaredUnit.Equals("kg", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    try
+                    {
+                        double volume = System.Convert.ToDouble(obj.CustomData["Volume"]);
+                        double constant = environmentalProductDeclaration.queryEnvironmentalProductDeclaration(environmentalProductDeclarationField);
+                        try
+                        {
+                            if (System.Convert.ToDouble(environmentalProductDeclaration.Density) != 0)
+                            {
+                                BH.Engine.Reflection.Compute.RecordNote("This method is using Density supplied by the EnvironmentalProductDeclaration to calculate Mass.");
+                                double density = System.Convert.ToDouble(environmentalProductDeclaration.Density);
+                                return volume * density * constant;
+                            }
+                        }
+                        catch
+                        {
+                            BH.Engine.Reflection.Compute.RecordNote("Unable to extract Density from the EnvironmentalProductDeclaration to calculate Mass. The method will attempt to extract the Density value from the object.");
+                        } //Try to extract density from the dataset.
+                        try
+                        {
+                            BH.Engine.Reflection.Compute.RecordNote("This method is using Density supplied by the CustomObject to calculate Mass. Please verify that you are supplying accurate values for Density.");
+                            double density = System.Convert.ToDouble(obj.CustomData["Density"]);
+                            return volume * density * constant;
+                        }
+                        catch
+                        {
+                            BH.Engine.Reflection.Compute.RecordError("This method requires an object to function. Please provide a BHoM CustomObject with Volume and Density properties stored in CustomData");
+                        } //Try to extract the density from the object.
+                    }
+                    catch
+                    {
+                        BH.Engine.Reflection.Compute.RecordError("The CustomObject must have Volume and Density properties within CustomData for this method to work.");
+                    } //Extract Density and Volume properties from available sources. 
+                }
+                else
+                {
+                    BH.Engine.Reflection.Compute.RecordError("This method requires a BHoM CustomObject with Volume and Density properties to function.Please verify these values and SetProperty to resume calculation.");
+                }
+
+                //if declared unit from EnvironmentalProductDeclaration is t (tonne).
+                if (environmentalProductDeclaration.DeclaredUnit != null && environmentalProductDeclaration.DeclaredUnit.Equals("t", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    BH.Engine.Reflection.Compute.RecordError("The declared unit of the EnvironmentalProductDeclaration is t (tonne). Because this is not standard practice, you should verify all units and data to ensure consistant results. Units will be converted from kgCO2/tonne to kgCO2/kg.");
+                    try
+                    {
+                        double volume = System.Convert.ToDouble(obj.CustomData["Volume"]);
+                        double constant = environmentalProductDeclaration.queryEnvironmentalProductDeclaration(environmentalProductDeclarationField) / 1000; //<---convert to kg. this convert is temporary until iElementM is functional.
+                        try
+                        {
+                            if (System.Convert.ToDouble(environmentalProductDeclaration.Density) != 0)
+                            {
+                                BH.Engine.Reflection.Compute.RecordNote("This method is using Density supplied by the EnvironmentalProductDeclaration to calculate Mass.");
+                                double density = System.Convert.ToDouble(environmentalProductDeclaration.Density);
+                                return volume * density * constant;
+                            }
+                        }
+                        catch
+                        {
+                            BH.Engine.Reflection.Compute.RecordNote("Unable to extract Density from the EnvironmentalProductDeclaration to calculate Mass. The method will attempt to extract the Density value from the object.");
+                        } //Try to extract density from the dataset.
+                        try
+                        {
+                            BH.Engine.Reflection.Compute.RecordNote("This method is using Density supplied by the CustomObject to calculate Mass. Please verify that you are supplying accurate values for Density.");
+                            double density = System.Convert.ToDouble(obj.CustomData["Density"]);
+                            return volume * density * constant;
+                        }
+                        catch
+                        {
+                            BH.Engine.Reflection.Compute.RecordError("This method requires an object to function. Please provide a BHoM CustomObject with Volume and Density properties stored in CustomData");
+                        } //Try to extract the density from the object.
+                    }
+                    catch
+                    {
+                        BH.Engine.Reflection.Compute.RecordError("The CustomObject must have Volume and Density properties within CustomData for this method to work.");
+                    } //Extract Density and Volume properties from available sources. 
+                }
+                else
+                {
+                    BH.Engine.Reflection.Compute.RecordError("This method requires a BHoM CustomObject with Volume and Density properties to function.Please verify these values and SetProperty to resume calculation.");
+                }
+
+                //if declared unit from EnvironmentalProductDeclaration is m2 (surface area).
+                if (environmentalProductDeclaration.DeclaredUnit != null && environmentalProductDeclaration.DeclaredUnit.Equals("m2", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    BH.Engine.Reflection.Compute.RecordError("The declared unit of the EnvironmentalProductDeclaration is area based (m2). You must therefore multiply the result by the surface area of the material you wish to evaluate.");
+                    try
+                    {
+                        double volume = System.Convert.ToDouble(obj.CustomData["Volume"]);
+                        double constant = environmentalProductDeclaration.queryEnvironmentalProductDeclaration(environmentalProductDeclarationField); //Prompt the user to multiply the value by the m2 of material being evaluated.
+                        try
+                        {
+                            if (System.Convert.ToDouble(environmentalProductDeclaration.Density) != 0)
+                            {
+                                BH.Engine.Reflection.Compute.RecordNote("This method is using Density supplied by the EnvironmentalProductDeclaration to calculate Mass.");
+                                double density = System.Convert.ToDouble(environmentalProductDeclaration.Density);
+                                return volume * density * constant;
+                            }
+                        }
+                        catch
+                        {
+                            BH.Engine.Reflection.Compute.RecordNote("Unable to extract Density from the EnvironmentalProductDeclaration to calculate Mass. The method will attempt to extract the Density value from the object.");
+                        } //Try to extract density from the dataset.
+                        try
+                        {
+                            BH.Engine.Reflection.Compute.RecordNote("This method is using Density supplied by the CustomObject to calculate Mass. Please verify that you are supplying accurate values for Density.");
+                            double density = System.Convert.ToDouble(obj.CustomData["Density"]);
+                            return volume * density * constant;
+                        }
+                        catch
+                        {
+                            BH.Engine.Reflection.Compute.RecordError("This method requires an object to function. Please provide a BHoM CustomObject with Volume and Density properties stored in CustomData");
+                        } //Try to extract the density from the object.
+                    }
+                    catch
+                    {
+                        BH.Engine.Reflection.Compute.RecordError("The CustomObject must have Volume and Density properties within CustomData for this method to work.");
+                    } //Extract Density and Volume properties from available sources. 
+                }
+                else
+                {
+                    BH.Engine.Reflection.Compute.RecordError("This method requires a BHoM CustomObject with Volume and Density properties to function.Please verify these values and SetProperty to resume calculation.");
+                }
+            }
+            else 
+            {
+                BH.Engine.Reflection.Compute.RecordError("This method requires a BHoM CustomObject and mass to function. Mass = Volume * Density: Please provide both Volume and Density properties within CustomData to resume calculation.");
+            }
+            return 0;
+        }
+
+        /***************************************************/
+
+        //<-----Additional method in progress to work with any geometry----->//
+
+        /*[Description("Calculates the acidification potential of a BHoM Object based on explicitly defined volume and Environmental Product Declaration dataset.")]
+        [Input("volume", "Volume in m^2 as a double. This method does not extract the Volume of an object and should be provided manually. The property may be extracted from an EPDData Object.")]
+        [Input("density", "Density in kg/m^3 as a double. This method does not extract the Density of an object and should be provided manually. The property may be extracted from an EPDData Object.")]
+        [Input("epdData", "BHoM EPDData object containing values for typical metrics within Environmental Product Declarations.")]
+        [Input("environmentalProductDeclarationField", "BHoM environmentalProductDeclarationField Enum to select Environmental Product Declaration metric for evaluation.")]
+        [Output("quantity", "The quantity of the specified EPD metric within a given geometry.")]
+        public static double EvaluateEPD(double volume = 0, double density = 0, EPDData epdData = null, environmentalProductDeclarationField environmentalProductDeclarationField = environmentalProductDeclarationField.GlobalWarmingPotential)
+        {
+            double calcDensity = double.NaN;
+
+            if (density != 0)
+            {
+                calcDensity = density;
+            }
+            else
+            {
+                BH.Engine.Reflection.Compute.RecordNote("Density value is either zero or is being derived from the epdData. Please verify the correct value within the dataset before continuing by using the explode component.");
+
+                if (System.Convert.ToDouble(epdData.Density) != 0)
+                {
+                    try
+                    {
+                        calcDensity = System.Convert.ToDouble(epdData.Density);
+                    }
+                    catch (Exception e)
+                    {
+                        BH.Engine.Reflection.Compute.RecordError("An error occurred in converting the custom data key Density to a valid number (double) - error was: " + e.ToString());
+                    }
+                }
+                if ((calcDensity == 0 || double.IsNaN(calcDensity)) && (density == 0 || double.IsNaN(density)))
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"Results cannot be calculated. Please check your input values for Density, Volume, and {environmentalProductDeclarationField}");
+                    return double.NaN;
+                }
+            }
+            return (volume * calcDensity) * CompileEPD(epdData, environmentalProductDeclarationField);
+        }*/
+    }
+}

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.LifeCycleAssessment
         [Input("environmentalProductDeclaration", "This is LifeCycleAssessment.EnvironmentalProductDeclaration data. Please select your desired dataset and supply your material choice to the corresponding BHoM objects.")]
         [Input("environmentalProductDeclarationField", "Filter the provided EnvironmentalProductDeclaration by selecting one of the provided metrics for calculation. This method also accepts multiple fields simultaneously.")]
         [Output("quantity", "The quantity of the desired metric provided by the EnvironmentalProductDeclarationField")]
-        public static double EvaluateEnvironmentalProductDeclarationPerObject(IBHoMObject obj, EnvironmentalProductDeclaration environmentalProductDeclaration, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential) //default to globalWarmingPotential evaluation
+        public static double EvaluateEnvironmentalProductDeclarationPerObject(IBHoMObject obj, IEnvironmentalProductDeclarationData environmentalProductDeclaration, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential) //default to globalWarmingPotential evaluation
         {
             if (obj != null)
             {
@@ -135,7 +135,7 @@ namespace BH.Engine.LifeCycleAssessment
         [Input("environmentalProductDeclarationField", "The metric to calculate total quantity for.")]
         [Input("mass", "The total mass to calculate the total quantity of the input metric for.",typeof(Mass))]
         [Output("quantity", "The total quantity of the desired metric based on the EnvironmentalProductDeclarationField")]
-        public static double EvaluateEnvironmentalProductDeclarationByMass(EnvironmentalProductDeclaration environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential, double mass = 0) //default to globalWarmingPotential evaluation
+        public static double EvaluateEnvironmentalProductDeclarationByMass(IEnvironmentalProductDeclarationData environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential, double mass = 0) //default to globalWarmingPotential evaluation
         {
             if (environmentalProductDeclaration.DeclaredUnitType() != "Mass")
             {
@@ -156,7 +156,7 @@ namespace BH.Engine.LifeCycleAssessment
         [Input("environmentalProductDeclarationField", "The metric to calculate total quantity for.")]
         [Input("volume", "The total volume to calculate the total quantity of the input metric for.", typeof(Volume))]
         [Output("quantity", "The total quantity of the desired metric based on the EnvironmentalProductDeclarationField")]
-        public static double EvaluateEnvironmentalProductDeclarationByVolume(EnvironmentalProductDeclaration environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential, double volume = 0)
+        public static double EvaluateEnvironmentalProductDeclarationByVolume(IEnvironmentalProductDeclarationData environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential, double volume = 0)
         {
             if (environmentalProductDeclaration.DeclaredUnitType() != "Volume")
             {
@@ -177,7 +177,7 @@ namespace BH.Engine.LifeCycleAssessment
         [Input("environmentalProductDeclarationField", "The metric to calculate total quantity for.")]
         [Input("area", "The total area to calculate the total quantity of the input metric for.", typeof(Area))]
         [Output("quantity", "The total quantity of the desired metric based on the EnvironmentalProductDeclarationField")]
-        public static double EvaluateEnvironmentalProductDeclarationByArea(EnvironmentalProductDeclaration environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential, double area = 0)
+        public static double EvaluateEnvironmentalProductDeclarationByArea(IEnvironmentalProductDeclarationData environmentalProductDeclaration = null, EnvironmentalProductDeclarationField environmentalProductDeclarationField = EnvironmentalProductDeclarationField.GlobalWarmingPotential, double area = 0)
         {
             if (environmentalProductDeclaration.DeclaredUnitType() != "Area")
             {

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
@@ -23,7 +23,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-//using BH.oM.Structure; <--This was used for IMass calc. Remove when IelementM is implemented.
 using System.ComponentModel;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
@@ -55,10 +54,11 @@ namespace BH.Engine.LifeCycleAssessment
                     BH.Engine.Reflection.Compute.RecordError("The input object must have a Volume property for this method to work.");
                     return 0;
                 }
+
                 double volume = System.Convert.ToDouble(vol);
-                if (volume == 0)
+                if (volume <= 0)
                 {
-                    BH.Engine.Reflection.Compute.RecordError("The input object's Volume value is invalid. Volume should be in m3 in numerical format.");
+                    BH.Engine.Reflection.Compute.RecordError("The input object's Volume value is invalid or negative. Volume should be in m3 in numerical format.");
                     return 0;
                 }
 
@@ -69,23 +69,23 @@ namespace BH.Engine.LifeCycleAssessment
                 {
                     return EvaluateEnvironmentalProductDeclarationByVolume(environmentalProductDeclaration, environmentalProductDeclarationField, volume);
                 }
-
                 else if (declaredUnitType == "Mass")
                 {
-                    double density = 0;
-                    string epdDensity = environmentalProductDeclaration.Density.ToString() ?? "";
-                    double densityVal = System.Convert.ToDouble(epdDensity.Substring(0, epdDensity.IndexOf(" ")));
-                    if (System.Convert.ToDouble(densityVal) != 0)
+                    //double density = 0;
+                    string epdDensity = environmentalProductDeclaration.Density != null ? environmentalProductDeclaration.Density.ToString() : "";
+                    double density = System.Convert.ToDouble(epdDensity.Substring(0, epdDensity.IndexOf(" "))); //substring required to parse density string. This is temporary until IElementM is integrated.
+                    
+                    if (System.Convert.ToDouble(density) != 0)
                     {
-                        density = densityVal;
+                        //density = density;
                         BH.Engine.Reflection.Compute.RecordNote(String.Format("This method is using a density of {0} supplied by the EnvironmentalProductDeclaration to calculate Mass.", density));
                     }
                     else if (obj.PropertyValue("Density") == null)
                     {
-                        BH.Engine.Reflection.Compute.RecordNote("The EnvironmentalProductDeclaration and input object do not have density information. The epd is mass-based. Please add density data to the input object.");
+                        BH.Engine.Reflection.Compute.RecordNote("The EnvironmentalProductDeclaration and input object do not have density information. The EPD is mass-based. Please add density data to the input object.");
                         return 0;
                     }
-                    else if (System.Convert.ToDouble(obj.PropertyValue("Density")) == 0)
+                    else if (System.Convert.ToDouble(obj.PropertyValue("Density")) <= 0)
                     {
                         BH.Engine.Reflection.Compute.RecordNote("The input object's Density value is invalid. Density should be in kg/m3 in numerical format.");
                         return 0;
@@ -94,21 +94,22 @@ namespace BH.Engine.LifeCycleAssessment
                     {
                         density = System.Convert.ToDouble(obj.PropertyValue("Density"));
                     }
+                    
                     double mass = density * volume;
 
                     return EvaluateEnvironmentalProductDeclarationByMass(environmentalProductDeclaration, environmentalProductDeclarationField, mass);
                 }
-
                 else if (declaredUnitType == "Area")
                 {
                     object ar = obj.PropertyValue("Area");
                     if (ar == null)
                     {
-                        BH.Engine.Reflection.Compute.RecordError("The EnvironmentalProductDeclaration supplied uses an area based declared unit, so the input object requires an Area property. ");
+                        BH.Engine.Reflection.Compute.RecordError("The EnvironmentalProductDeclaration supplied uses an area based declared unit, so the input object requires an Area property.");
                         return 0;
                     }
+                    
                     double area = System.Convert.ToDouble(ar);
-                    if (area == 0)
+                    if (area <= 0)
                     {
                         BH.Engine.Reflection.Compute.RecordError("The input object's Area value is invalid. Area should be in m2 in numerical format.");
                         return 0;
@@ -138,7 +139,7 @@ namespace BH.Engine.LifeCycleAssessment
         {
             if (environmentalProductDeclaration.DeclaredUnitType() != "Mass")
             {
-                BH.Engine.Reflection.Compute.RecordError("This EnvironmentalProductDeclaration's declared unit type is not Mass. Please supply a Mass-based epd or try a different method.");
+                BH.Engine.Reflection.Compute.RecordError("This EnvironmentalProductDeclaration's declared unit type is not Mass. Please supply a Mass-based EPD or try a different method.");
                 return 0;
             }
             else
@@ -159,7 +160,7 @@ namespace BH.Engine.LifeCycleAssessment
         {
             if (environmentalProductDeclaration.DeclaredUnitType() != "Volume")
             {
-                BH.Engine.Reflection.Compute.RecordError("This EnvironmentalProductDeclaration's declared unit type is not Volume. Please supply a Volume-based epd or try a different method.");
+                BH.Engine.Reflection.Compute.RecordError("This EnvironmentalProductDeclaration's declared unit type is not Volume. Please supply a Volume-based EPD or try a different method.");
                 return 0;
             }
             else
@@ -180,7 +181,7 @@ namespace BH.Engine.LifeCycleAssessment
         {
             if (environmentalProductDeclaration.DeclaredUnitType() != "Area")
             {
-                BH.Engine.Reflection.Compute.RecordError("This EnvironmentalProductDeclaration's declared unit type is not Area. Please supply an Area-based epd or try a different method.");
+                BH.Engine.Reflection.Compute.RecordError("This EnvironmentalProductDeclaration's declared unit type is not Area. Please supply an Area-based EPD or try a different method.");
                 return 0;
             }
             else

--- a/LifeCycleAssessment_Engine/Convert/ToEnvironmentalProductDeclarationData.cs
+++ b/LifeCycleAssessment_Engine/Convert/ToEnvironmentalProductDeclarationData.cs
@@ -59,8 +59,6 @@ namespace BH.Engine.LifeCycleAssessment
                 Description = obj.PropertyValue("Description")?.ToString() ?? "",
                 DeclaredUnit = obj.PropertyValue("DeclaredUnit")?.ToString() ?? "",
                 BiogenicEmbodiedCarbon = obj.PropertyValue("BiogenicEmbodiedCarbon") != null ? System.Convert.ToDouble(obj.PropertyValue("BiogenicEmbodiedCarbon")) : double.NaN,
-                GwpPerDeclaredUnit = obj.PropertyValue("GwpPerDeclaredUnit")?.ToString() ?? "",
-                GwpPerKG = obj.PropertyValue("GwpPerKG")?.ToString() ?? "", //needs string splitting to extract units and convert to double.
                 Density = obj.PropertyValue("Density")?.ToString() ?? "", //additional converts needed because this type is string not double.
                 EndOfLifeTreatment = obj.PropertyValue("EolTreatment")?.ToString() ?? "",
                 Source = obj,

--- a/LifeCycleAssessment_Engine/Convert/ToSectorEnvironmentalProductDeclarationData.cs
+++ b/LifeCycleAssessment_Engine/Convert/ToSectorEnvironmentalProductDeclarationData.cs
@@ -59,8 +59,6 @@ namespace BH.Engine.LifeCycleAssessment
                 Description = obj.PropertyValue("Description")?.ToString() ?? "",
                 DeclaredUnit = obj.PropertyValue("DeclaredUnit")?.ToString() ?? "",
                 BiogenicEmbodiedCarbon = obj.PropertyValue("BiogenicEmbodiedCarbon") != null ? System.Convert.ToDouble(obj.PropertyValue("BiogenicEmbodiedCarbon")) : double.NaN,
-                GwpPerDeclaredUnit = obj.PropertyValue("GwpPerDeclaredUnit")?.ToString() ?? "",
-                GwpPerKG = obj.PropertyValue("GwpPerKG")?.ToString() ?? "", //needs string splitting to extract units and convert to double.
                 Density = obj.PropertyValue("Density")?.ToString() ?? "", //additional converts needed because this type is string not double.
                 EndOfLifeTreatment = obj.PropertyValue("EolTreatment")?.ToString() ?? "",
                 Source = obj,

--- a/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
+++ b/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
@@ -34,6 +34,10 @@
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Quantities_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Quantities_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
@@ -61,7 +65,9 @@
     <Compile Include="Convert\ToEnvironmentalProductDeclarationData.cs" />
     <Compile Include="Convert\ToSectorEnvironmentalProductDeclarationData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Query\QueryEnvironmentalProductDeclaration.cs" />
+    <Compile Include="Query\DeclaredUnitType.cs" />
+    <Compile Include="Query\DeclaredUnitInSI.cs" />
+    <Compile Include="Query\EnvironmentalProductDeclaration.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Create\" />

--- a/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
+++ b/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
@@ -37,18 +37,22 @@
     <Reference Include="Quantities_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Quantities_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Structure_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Structure_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -77,6 +81,7 @@
     <ProjectReference Include="..\LifeCycleAssessment_oM\LifeCycleAssessment_oM.csproj">
       <Project>{0f693e7c-1a4e-42ad-a3d8-d6ce16acae5c}</Project>
       <Name>LifeCycleAssessment_oM</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
+++ b/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
@@ -56,16 +56,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\EvaluateEnvironmentalProductDeclaration.cs" />
     <Compile Include="Convert\ToHealthProductDeclarationData.cs" />
     <Compile Include="Convert\ToEnvironmentalProductDeclarationData.cs" />
     <Compile Include="Convert\ToSectorEnvironmentalProductDeclarationData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\QueryEnvironmentalProductDeclaration.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Compute\" />
     <Folder Include="Create\" />
     <Folder Include="Modify\" />
-    <Folder Include="Query\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LifeCycleAssessment_oM\LifeCycleAssessment_oM.csproj">

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.LifeCycleAssessment;
+
+namespace BH.Engine.LifeCycleAssessment
+{
+    public static partial class Query
+    {
+        public static double DeclaredUnitValueInSI(this EnvironmentalProductDeclaration epd)
+        {
+            //Temporary method to be replaced by epd.DeclaredUnit convert to volume or mass using IMatter
+            if (epd.DeclaredUnit != null)
+            {
+                switch (epd.DeclaredUnit)
+                {
+                    case "1 kg":
+                        return 1;
+                    case "1 lbs":
+                        return 0.453592;
+                    case "1 t":
+                        return 1000;
+                    case "1 m3":
+                        return 1;
+                    case "1 yd3":
+                        return 0.764555;
+                    case "1 m2":
+                        return 1;
+                    case "1 ft2":
+                        return 0.092903;
+                    case "1000 ft2":
+                        return 9.2903;
+                    default:
+                        return double.NaN;
+                }
+            }
+            else { return double.NaN; }         
+        }
+    }
+}

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
@@ -61,7 +61,7 @@ namespace BH.Engine.LifeCycleAssessment
                         return double.NaN;
                 }
             }
-            else { return double.NaN; }         
+            return double.NaN;      
         }
     }
 }

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.LifeCycleAssessment
 {
     public static partial class Query
     {
-        public static double DeclaredUnitValueInSI(this EnvironmentalProductDeclaration epd)
+        public static double DeclaredUnitValueInSI(this IEnvironmentalProductDeclarationData epd)
         {
             //Temporary method to be replaced by epd.DeclaredUnit convert to volume or mass using IMatter
             if (epd.DeclaredUnit != null)

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
@@ -52,8 +52,10 @@ namespace BH.Engine.LifeCycleAssessment
                     case "1 m2":
                         return 1;
                     case "1 ft2":
+                    case "1 sqft":
                         return 0.092903;
                     case "1000 ft2":
+                    case "1000 sqft":
                         return 9.2903;
                     default:
                         return double.NaN;

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitInSI.cs
@@ -40,6 +40,7 @@ namespace BH.Engine.LifeCycleAssessment
                 switch (epd.DeclaredUnit)
                 {
                     case "1 kg":
+                    case "kg":
                         return 1;
                     case "1 lbs":
                         return 0.453592;

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
@@ -48,7 +48,9 @@ namespace BH.Engine.LifeCycleAssessment
                         return "Volume";
                     case "1 m2":
                     case "1 ft2":
+                    case "1 sqft":
                     case "1000 ft2":
+                    case "1000 sqft":
                         return "Area";
                     case "1 m":
                     case "1 ft":

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.LifeCycleAssessment;
+
+namespace BH.Engine.LifeCycleAssessment
+{
+    public static partial class Query
+    {
+        public static string DeclaredUnitType(this EnvironmentalProductDeclaration epd)
+        {
+            //Temporary method to be replaced by epd.DeclaredUnit convert to volume or mass using IMatter
+            if (epd.DeclaredUnit != null)
+            {
+                switch (epd.DeclaredUnit)
+                {
+                    case "1 kg":
+                    case "1 lbs":
+                    case "1 t":
+                        return "Mass";
+                    case "1 m3":
+                    case "1 yd3":
+                        return "Volume";
+                    case "1 m2":
+                    case "1 ft2":
+                    case "1000 ft2":
+                        return "Area";
+                    case "1 m":
+                    case "1 ft":
+                        return "Length";
+                    default:
+                        return "Unrecognized";
+                }
+            }
+            else { return null; }         
+        }
+    }
+}

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
@@ -59,7 +59,7 @@ namespace BH.Engine.LifeCycleAssessment
                         return "Unrecognized";
                 }
             }
-            else { return null; }         
+            return null;        
         }
     }
 }

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.LifeCycleAssessment
 {
     public static partial class Query
     {
-        public static string DeclaredUnitType(this EnvironmentalProductDeclaration epd)
+        public static string DeclaredUnitType(this IEnvironmentalProductDeclarationData epd)
         {
             //Temporary method to be replaced by epd.DeclaredUnit convert to volume or mass using IMatter
             if (epd.DeclaredUnit != null)

--- a/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
+++ b/LifeCycleAssessment_Engine/Query/DeclaredUnitType.cs
@@ -40,6 +40,7 @@ namespace BH.Engine.LifeCycleAssessment
                 switch (epd.DeclaredUnit)
                 {
                     case "1 kg":
+                    case "kg":
                     case "1 lbs":
                     case "1 t":
                         return "Mass";

--- a/LifeCycleAssessment_Engine/Query/EnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Query/EnvironmentalProductDeclaration.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.LifeCycleAssessment
 {
     public static partial class Query
     {
-        public static double EnvironmentalProductDeclaration(this EnvironmentalProductDeclaration epd, EnvironmentalProductDeclarationField field)
+        public static double EnvironmentalProductDeclaration(this IEnvironmentalProductDeclarationData epd, EnvironmentalProductDeclarationField field)
         {
             switch(field)
             {

--- a/LifeCycleAssessment_Engine/Query/EnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Query/EnvironmentalProductDeclaration.cs
@@ -32,12 +32,12 @@ namespace BH.Engine.LifeCycleAssessment
 {
     public static partial class Query
     {
-        public static double queryEnvironmentalProductDeclaration(this EnvironmentalProductDeclaration epd, EnvironmentalProductDeclarationField field)
+        public static double EnvironmentalProductDeclaration(this EnvironmentalProductDeclaration epd, EnvironmentalProductDeclarationField field)
         {
             switch(field)
             {
                 case EnvironmentalProductDeclarationField.GlobalWarmingPotential:
-                    return epd.GlobalWarmingPotential;
+                    return epd.GlobalWarmingPotential; // need to return per gwp available
                 case EnvironmentalProductDeclarationField.OzoneDepletionPotential:
                     return epd.OzoneDepletionPotential;
                 case EnvironmentalProductDeclarationField.PhotochemicalOzoneCreationPotential:

--- a/LifeCycleAssessment_Engine/Query/QueryEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Query/QueryEnvironmentalProductDeclaration.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/LifeCycleAssessment_Engine/Query/QueryEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Query/QueryEnvironmentalProductDeclaration.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.LifeCycleAssessment;
+
+namespace BH.Engine.LifeCycleAssessment
+{
+    public static partial class Query
+    {
+        public static double queryEnvironmentalProductDeclaration(this EnvironmentalProductDeclaration epd, EnvironmentalProductDeclarationField field)
+        {
+            switch(field)
+            {
+                case EnvironmentalProductDeclarationField.GlobalWarmingPotential:
+                    return epd.GlobalWarmingPotential;
+                case EnvironmentalProductDeclarationField.OzoneDepletionPotential:
+                    return epd.OzoneDepletionPotential;
+                case EnvironmentalProductDeclarationField.PhotochemicalOzoneCreationPotential:
+                    return epd.PhotochemicalOzoneCreationPotential;
+                case EnvironmentalProductDeclarationField.AcidificationPotential:
+                    return epd.AcidificationPotential;
+                case EnvironmentalProductDeclarationField.EutrophicationPotential:
+                    return epd.EutrophicationPotential;
+                case EnvironmentalProductDeclarationField.DepletionOfAbioticResourcesFossilFuels:
+                    return epd.DepletionOfAbioticResourcesFossilFuels;
+                case EnvironmentalProductDeclarationField.GlobalWarmingPotentialEndOfLife:
+                    return epd.GlobalWarmingPotentialEndOfLife;
+                case EnvironmentalProductDeclarationField.OzoneDepletionPotentialEndOfLife:
+                    return epd.OzoneDepletionPotentialEndOfLife;
+                case EnvironmentalProductDeclarationField.PhotochemicalOzoneCreationPotentialEndOfLife:
+                    return epd.PhotochemicalOzoneCreationPotentialEndOfLife;
+                case EnvironmentalProductDeclarationField.AcidificationPotentialEndOfLife:
+                    return epd.AcidificationPotentialEndOfLife;
+                case EnvironmentalProductDeclarationField.EutrophicationPotentialEndOfLife:
+                    return epd.EutrophicationPotentialEndOfLife;
+                case EnvironmentalProductDeclarationField.DepletionOfAbioticResourcesFossilFuelsEndOfLife:
+                    return epd.DepletionOfAbioticResourcesFossilFuelsEndOfLife;
+                default:
+                    return 0;
+            }
+        }
+    }
+}

--- a/LifeCycleAssessment_oM/Enums/EnvironmentalProductDeclarationField.cs
+++ b/LifeCycleAssessment_oM/Enums/EnvironmentalProductDeclarationField.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.oM.LifeCycleAssessment
+{
+    public enum EnvironmentalProductDeclarationField
+    {
+        GlobalWarmingPotential,
+        OzoneDepletionPotential,
+        PhotochemicalOzoneCreationPotential,
+        AcidificationPotential,
+        EutrophicationPotential,
+        DepletionOfAbioticResourcesFossilFuels,
+        GlobalWarmingPotentialEndOfLife,
+        OzoneDepletionPotentialEndOfLife,
+        PhotochemicalOzoneCreationPotentialEndOfLife,
+        AcidificationPotentialEndOfLife,
+        EutrophicationPotentialEndOfLife,
+        DepletionOfAbioticResourcesFossilFuelsEndOfLife,
+        //add more evaluation properties when needed.
+    }
+}

--- a/LifeCycleAssessment_oM/Enums/EnvironmentalProductDeclarationField.cs
+++ b/LifeCycleAssessment_oM/Enums/EnvironmentalProductDeclarationField.cs
@@ -20,8 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.ComponentModel;
+
 namespace BH.oM.LifeCycleAssessment
 {
+    [Description("This enum provides several evaluation fields that are commonly assessed within standard Environmental Product Declarations. You may provide single or multiple EPD Field selections for evaluation within the EvaluateEnvironmentalProductDeclaration compute method.")]
     public enum EnvironmentalProductDeclarationField
     {
         GlobalWarmingPotential,

--- a/LifeCycleAssessment_oM/IEnvironmentalProductDeclarationData.cs
+++ b/LifeCycleAssessment_oM/IEnvironmentalProductDeclarationData.cs
@@ -33,7 +33,7 @@ namespace BH.oM.LifeCycleAssessment
         string Id { get; set; }
         string Density { get; set; }
         double BiogenicEmbodiedCarbon { get; set; }
-        string DeclaredUnit { get; set; } // <---- make sure this is always populated 
+        string DeclaredUnit { get; set; }
         string Description { get; set; }
         string Scope { get; set; }
         double GlobalWarmingPotential { get; set; }

--- a/LifeCycleAssessment_oM/LifeCycleAssessment_oM.csproj
+++ b/LifeCycleAssessment_oM/LifeCycleAssessment_oM.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enums\EnvironmentalProductDeclarationField.cs" />
     <Compile Include="HealthProductDeclaration.cs" />
     <Compile Include="IEnvironmentalProductDeclarationData.cs" />
     <Compile Include="EnvironmentalProductDeclaration.cs" />


### PR DESCRIPTION
Includes query method for switch case filtering with the provided EPD data.

Closes #42 

<!-- Add short description of what has been fixed -->
Compute method architecture has been adjusted from original ClimateEmergency [PR](https://github.com/BHoM/ClimateEmergency_Toolkit/pull/53). The method queries the dataset for the declared unit (currently; kg, t, m2) prior to selecting a specific calc method and returning errors/notes to the user. This method is heavily reliant upon user feedback to communicate proper LifeCycleAssessment coordination. 

The method also makes use of an enum representing typical EnvironmentalProductDeclaration evaluations to avoid having separate methods for each category.

*The handling of unit conversion is meant to be temporary until **iElementM** work concludes. Another issue should then be raised to remove any unit conversions and implement the new framework. Currently the only unit being converted is t (kg/1000) Please comment if correction is needed.*