### PR TITLE
Evaluation methods working with MaterialComposition

### DIFF
--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByArea.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByArea.cs
@@ -52,7 +52,9 @@ namespace BH.Engine.LifeCycleAssessment
             }
             else
             {
-                double epdVal = (elementM as IBHoMObject).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault().GetEvaluationValue(field);
+                double area = (elementM as IElement2D).Area();
+                double epdVal = elementM.GetEvaluationValue(field);
+                double quantity = area * epdVal;
 
                 if (epdVal <= 0 || epdVal == double.NaN)
                 {
@@ -60,15 +62,11 @@ namespace BH.Engine.LifeCycleAssessment
                     return null;
                 }
 
-                double area = (elementM as IElement2D).Area();
-
                 if (area <= 0 || area == double.NaN)
                 {
                     BH.Engine.Reflection.Compute.RecordError("Area cannot be calculated from object " + ((IBHoMObject)elementM).BHoM_Guid);
                     return null;
                 }
-
-                double quantity = area * epdVal;
 
                 return new GlobalWarmingPotentialResult(((IBHoMObject)elementM).BHoM_Guid, "GWP", 0, ObjectScope.Undefined, ObjectCategory.Undefined, ((IBHoMObject)elementM).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault(), quantity);
             }

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
@@ -52,7 +52,9 @@ namespace BH.Engine.LifeCycleAssessment
             }
             else
             {
-                double epdVal = (elementM as IBHoMObject).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault().GetEvaluationValue(field);
+                double mass = elementM.Mass();
+                double epdVal = elementM.GetEvaluationValue(field);
+                double quantity = mass * epdVal;
 
                 if (epdVal <= 0 || epdVal == double.NaN)
                 {
@@ -60,15 +62,11 @@ namespace BH.Engine.LifeCycleAssessment
                     return null;
                 }
 
-                double mass = elementM.Mass();
-
                 if (mass <= 0 || mass == double.NaN)
                 {
                     BH.Engine.Reflection.Compute.RecordError("Mass cannot be calculated from object " + ((IBHoMObject)elementM).BHoM_Guid);
                     return null;
                 }
-
-                double quantity = mass * epdVal;
 
                 return new GlobalWarmingPotentialResult(((IBHoMObject)elementM).BHoM_Guid, "GWP", 0, ObjectScope.Undefined, ObjectCategory.Undefined, ((IBHoMObject)elementM).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault(), quantity);
             }

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByVolume.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByVolume.cs
@@ -52,7 +52,9 @@ namespace BH.Engine.LifeCycleAssessment
             }
             else
             {
-                double epdVal = (elementM as IBHoMObject).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault().GetEvaluationValue(field);
+                double volume = elementM.ISolidVolume();
+                double epdVal = elementM.GetEvaluationValue(field);
+                double quantity = volume * epdVal;
 
                 if (epdVal <= 0 || epdVal == double.NaN)
                 {
@@ -60,15 +62,11 @@ namespace BH.Engine.LifeCycleAssessment
                     return null;
                 }
 
-                double volume = elementM.ISolidVolume();
-
                 if (volume <= 0)
                 {
                     BH.Engine.Reflection.Compute.RecordError("Volume cannot be calculated from object " + ((IBHoMObject)elementM).BHoM_Guid);
                     return null;
                 }
-
-                double quantity = volume * epdVal;
 
                 return new GlobalWarmingPotentialResult(((IBHoMObject)elementM).BHoM_Guid, "GWP", 0, ObjectScope.Undefined, ObjectCategory.Undefined, ((IBHoMObject)elementM).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault(), quantity);
             }

--- a/LifeCycleAssessment_Engine/Query/GetEvaluationValue.cs
+++ b/LifeCycleAssessment_Engine/Query/GetEvaluationValue.cs
@@ -24,10 +24,12 @@ using System.ComponentModel;
 using System.Linq;
 using BH.Engine.Base;
 using BH.oM.Base;
+using BH.oM.Dimensional;
 using BH.oM.LifeCycleAssessment;
 using BH.oM.LifeCycleAssessment.MaterialFragments;
 using BH.oM.MEP.Elements;
 using BH.oM.Reflection.Attributes;
+using BH.Engine.Matter;
 
 namespace BH.Engine.LifeCycleAssessment
 {
@@ -61,6 +63,26 @@ namespace BH.Engine.LifeCycleAssessment
                 default:
                     return double.NaN;
             }
+        }
+
+        /***************************************************/
+
+        [Description("Return a sum of all Material Fragment values from a specified EnvironmentalProductDeclarationField within any EPD object.")]
+        [Input("elementM", "An IElementM object used to calculate EPD metric.")]
+        [Input("field", "Specific metric to query from provided Environmental Product Declarations.")]
+        public static double GetEvaluationValue(this IElementM elementM, EnvironmentalProductDeclarationField field)
+        {
+            if (elementM == null)
+                return double.NaN;
+
+            double epdVal = elementM.IMaterialComposition().Materials.Select(x =>
+            {
+                var epd = x.Properties.Where(y => y is IEnvironmentalProductDeclarationData).FirstOrDefault() as IEnvironmentalProductDeclarationData;
+
+                return GetEvaluationValue(epd, field);
+            }).Sum();
+
+            return epdVal;
         }
 
         /***************************************************/

--- a/LifeCycleAssessment_Engine/Query/GetFragmentQuantityType.cs
+++ b/LifeCycleAssessment_Engine/Query/GetFragmentQuantityType.cs
@@ -20,20 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Net.NetworkInformation;
-using System.Text;
-using System.Threading.Tasks;
-using BH.Engine.Base;
-using BH.Engine.Reflection;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Base;
 using BH.oM.Dimensional;
 using BH.oM.LifeCycleAssessment;
 using BH.oM.LifeCycleAssessment.MaterialFragments;
+using BH.Engine.Matter;
 
 namespace BH.Engine.LifeCycleAssessment
 {
@@ -65,7 +58,17 @@ namespace BH.Engine.LifeCycleAssessment
             if (elementM == null)
                 return oM.LifeCycleAssessment.QuantityType.Undefined;
 
-            return ((IBHoMObject)elementM).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault().QuantityType;
+            QuantityType qt = elementM.IMaterialComposition().Materials.Select(x =>
+            {
+                var epd = x.Properties.Where(y => y is IEnvironmentalProductDeclarationData).FirstOrDefault() as IEnvironmentalProductDeclarationData;
+                if (epd != null)
+                    return epd.QuantityType;
+                return oM.LifeCycleAssessment.QuantityType.Undefined;
+            }).Where(x => x != null).FirstOrDefault();
+
+            return qt;
         }
+
+        /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #156 

<!-- Add short description of what has been fixed -->
All core evaluation compute methods now solve through values from the object's MaterialComposition. This is a fundamental shift in how the methods have been functioning to this point, as they no longer require fragment additions to the objects themselves, and now need to be added through Constructions or MaterialCompositions. 

Some thought has gone into the UI at the `GetEvaluationValue()` to inform the user if they are trying to evaluate fundamentally different EPD (varying quantityTypes). I believe this will improve the way materials are set and accessed. Additionally, this change will prepare for helpful material mapping methods in a future PR. 

### Test files
<!-- Link to test files to validate the proposed changes -->
[Here is a test file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/LifeCycleAssessment_Toolkit/LifeCycleAssessment_Toolkit-%23156%20MaterialComposition.gh?csf=1&web=1&e=ccoB8B)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->