### PR TITLE
Evaluate methods update to support multiple material ratios and volumes

### DIFF
--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclaration.cs
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,12 +31,11 @@ using BH.oM.LifeCycleAssessment.MaterialFragments;
 using BH.oM.LifeCycleAssessment.Results;
 using BH.oM.Physical.Elements;
 using BH.oM.Dimensional;
-
+using BH.Engine.Physical;
 using BH.Engine.Base;
 using BH.Engine.Reflection;
 using BH.Engine.Spatial;
 using BH.Engine.Matter;
-
 namespace BH.Engine.LifeCycleAssessment
 {
     public static partial class Compute
@@ -45,7 +43,6 @@ namespace BH.Engine.LifeCycleAssessment
         /***************************************************/
         /****   Public Methods                          ****/
         /***************************************************/
-
         [Description("This method calculates the results of any selected metric within an Environmental Product Declaration. For example for an EPD of QuantityType Volume, results will reflect the objects volume * EPD Field metric.")]
         [Input("elementM", "This is a BHoM object used to calculate EPD metric. This obj must have an EPD MaterialFragment applied to the object.")]
         [Input("field", "Filter the provided EnvironmentalProductDeclaration by selecting one of the provided metrics for calculation. This method also accepts multiple fields simultaneously.")]
@@ -53,20 +50,29 @@ namespace BH.Engine.LifeCycleAssessment
         [PreviousVersion("4.0", "BH.Engine.LifeCycleAssessment.Compute.EvaluateEnvironmentalProductDeclarationPerObject(BH.oM.Base.IBHoMObject, BH.oM.LifeCycleAssessment.EnvironmentalProductDeclarationField)")]
         public static LifeCycleAssessmentElementResult EvaluateEnvironmentalProductDeclarationPerObject(IElementM elementM, EnvironmentalProductDeclarationField field = EnvironmentalProductDeclarationField.GlobalWarmingPotential)
         {
-            QuantityType qt = elementM.QuantityType();
-            
+            QuantityType qt = elementM.GetFragmentQuantityType();
+
             switch (qt)
             {
+                case QuantityType.Undefined:
+                    BH.Engine.Reflection.Compute.RecordError("The object's EPD QuantityType is Undefined and cannot be evaluated.");
+                    return null;
+                case QuantityType.Item:
+                    BH.Engine.Reflection.Compute.RecordError("Length QuantityType is currently not supported. Try a different EPD with QuantityType values of either Area, Volume, or Mass.");
+                    return null;
+                case QuantityType.Length:
+                    BH.Engine.Reflection.Compute.RecordError("Length QuantityType is currently not supported. Try a different EPD with QuantityType values of either Area, Volume, or Mass.");
+                    return null;
                 case QuantityType.Area:
-                    BH.Engine.Reflection.Compute.RecordNote("Evaluating object based on EPD Area QuantityType.");
+                    BH.Engine.Reflection.Compute.RecordNote("Evaluating object type: " + elementM.GetType() + " based on EPD Area QuantityType.");
                     return EvaluateEnvironmentalProductDeclarationByArea(elementM, field);
                 case QuantityType.Volume:
-                    BH.Engine.Reflection.Compute.RecordNote("Evaluating object based on EPD Volume QuantityType.");
+                    BH.Engine.Reflection.Compute.RecordNote("Evaluating object type: " + elementM.GetType() + " based on EPD Volume QuantityType.");
                     return EvaluateEnvironmentalProductDeclarationByVolume(elementM, field);
                 case QuantityType.Mass:
-                    BH.Engine.Reflection.Compute.RecordNote("Evaluating object based on EPD Mass QuantityType.");
+                    BH.Engine.Reflection.Compute.RecordNote("Evaluating object type: " + elementM.GetType() + " based on EPD Mass QuantityType.");
                     return EvaluateEnvironmentalProductDeclarationByMass(elementM, field);
-                default:        
+                default:
                     BH.Engine.Reflection.Compute.RecordWarning("The object you have provided does not contain an EPD Material Fragment.");
                     return null;
             }

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByVolume.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByVolume.cs
@@ -22,6 +22,7 @@
 
 using System.Linq;
 using System.ComponentModel;
+using System.Collections.Generic;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using BH.oM.LifeCycleAssessment;
@@ -42,21 +43,25 @@ namespace BH.Engine.LifeCycleAssessment
         [Description("This method calculates the quantity of a supplied metric by querying Environmental Impact Metrics from the EPD materialFragment and the object's volume.")]
         [Input("elementM", "An IElementM object used to calculate EPD metric.")]
         [Input("field", "Filter the provided EnvironmentalProductDeclaration by selecting one of the provided metrics for calculation.")]
-        [Output("quantity", "The total quantity of the desired metric based on the EnvironmentalProductDeclarationField")]
+        [Output("quantity", "The total quantity of the desired metric based on the EnvironmentalProductDeclarationField.")]
         public static GlobalWarmingPotentialResult EvaluateEnvironmentalProductDeclarationByVolume(IElementM elementM = null, EnvironmentalProductDeclarationField field = EnvironmentalProductDeclarationField.GlobalWarmingPotential)
         {
-            if (elementM.QuantityType() != QuantityType.Volume)
+            if (elementM.GetFragmentQuantityType() != QuantityType.Volume)
             {
                 BH.Engine.Reflection.Compute.RecordError("This EnvironmentalProductDeclaration's QuantityType is not Volume. Please supply a Volume-based EPD or try a different method.");
                 return null;
             }
             else
             {
+                List<double> epdVal = elementM.GetEvaluationValue(field);
                 double volume = elementM.ISolidVolume();
-                double epdVal = elementM.GetEvaluationValue(field);
-                double quantity = volume * epdVal;
+                List<double> volumeByRatio = elementM.IMaterialComposition().Ratios.Select(x => volume * x).ToList();
+                List<double> gwpByMaterial = new List<double>();
 
-                if (epdVal <= 0 || epdVal == double.NaN)
+                for (int x = 0; x < epdVal.Count; x++)
+                    gwpByMaterial.Add(epdVal[x] * volumeByRatio[x]);
+
+                if (epdVal.Sum() <= 0 || epdVal == null)
                 {
                     BH.Engine.Reflection.Compute.RecordError($"No value for {field} can be found within the supplied EPD.");
                     return null;
@@ -68,7 +73,10 @@ namespace BH.Engine.LifeCycleAssessment
                     return null;
                 }
 
-                return new GlobalWarmingPotentialResult(((IBHoMObject)elementM).BHoM_Guid, "GWP", 0, ObjectScope.Undefined, ObjectCategory.Undefined, ((IBHoMObject)elementM).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault(), quantity);
+                double quantity = gwpByMaterial.Sum();
+
+                return new GlobalWarmingPotentialResult(((IBHoMObject)elementM).BHoM_Guid, field, 0, ObjectScope.Undefined, ObjectCategory.Undefined, ((IBHoMObject)elementM).GetAllFragments().Where(y => typeof(IEnvironmentalProductDeclarationData).IsAssignableFrom(y.GetType())).Select(z => z as IEnvironmentalProductDeclarationData).FirstOrDefault(), quantity);
+
             }
         }
 

--- a/LifeCycleAssessment_Engine/Compute/EvaluateLifeCycleAssessment.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateLifeCycleAssessment.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.LifeCycleAssessment
             results.AddRange(lca.MEPScope.EvaluateLifeCycleAssessmentScope(field));
             results.AddRange(lca.TenantImprovementScope.EvaluateLifeCycleAssessmentScope(field));
 
-            return new LifeCycleAssessmentResult(lca.BHoM_Guid, "GWP", 0, lca.LifeCycleAssessmentScope, new System.Collections.ObjectModel.ReadOnlyCollection<LifeCycleAssessmentElementResult>(results), results.TotalGlobalWarmingPotential());
+            return new LifeCycleAssessmentResult(lca.BHoM_Guid, field, 0, lca.LifeCycleAssessmentScope, new System.Collections.ObjectModel.ReadOnlyCollection<LifeCycleAssessmentElementResult>(results), results.TotalGlobalWarmingPotential());
         }
         /***************************************************/
     }

--- a/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
+++ b/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
@@ -74,7 +74,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Physical_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Physical_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Physical_oM">

--- a/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
+++ b/LifeCycleAssessment_Engine/LifeCycleAssessment_Engine.csproj
@@ -73,6 +73,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\MEP_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Physical_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Physical_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
@@ -136,6 +140,7 @@
     <Compile Include="Compute\EvaluateEnvironmentalProductDeclarationByMass.cs" />
     <Compile Include="Compute\EvaluateLifeCycleAssessment.cs" />
     <Compile Include="Compute\EvaluateLifeCycleAssessmentScope.cs" />
+    <Compile Include="Query\GetQuantityTypeValue.cs" />
     <Compile Include="Query\MaterialEndOfLifeTreatment.cs" />
     <Compile Include="Compute\ReinforcementVolume.cs" />
     <Compile Include="Compute\GlazingVolume.cs" />

--- a/LifeCycleAssessment_Engine/Query/GetFragmentQuantityType.cs
+++ b/LifeCycleAssessment_Engine/Query/GetFragmentQuantityType.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.LifeCycleAssessment
         [Description("Query the QuantityType value from any IEnvironmentalProductDeclarationData object.")]
         [Input("epd", "IEnvironmentalProductDeclarationData object from which to query.")]
         [Output("quantityType", "The quantityType value from the provided IEPD.")]
-        public static object GetFragmentQuantityType(this IEnvironmentalProductDeclarationData epd)
+        public static QuantityType GetFragmentQuantityType(this IEnvironmentalProductDeclarationData epd)
         {
             if (epd == null)
             {
@@ -53,17 +53,17 @@ namespace BH.Engine.LifeCycleAssessment
         [Description("Query the QuantityType value from any IElementM object's Fragments.")]
         [Input("elementM", "The IElementM object from which to query the EPD's QuantityType value.")]
         [Output("quantityType", "The quantityType value from the provided IEPD.")]
-        public static QuantityType QuantityType(this IElementM elementM)
+        public static QuantityType GetFragmentQuantityType(this IElementM elementM)
         {
             if (elementM == null)
-                return oM.LifeCycleAssessment.QuantityType.Undefined;
+                return QuantityType.Undefined;
 
             QuantityType qt = elementM.IMaterialComposition().Materials.Select(x =>
             {
                 var epd = x.Properties.Where(y => y is IEnvironmentalProductDeclarationData).FirstOrDefault() as IEnvironmentalProductDeclarationData;
                 if (epd != null)
                     return epd.QuantityType;
-                return oM.LifeCycleAssessment.QuantityType.Undefined;
+                return QuantityType.Undefined;
             }).Where(x => x != null).FirstOrDefault();
 
             return qt;

--- a/LifeCycleAssessment_Engine/Query/GetQuantityTypeValue.cs
+++ b/LifeCycleAssessment_Engine/Query/GetQuantityTypeValue.cs
@@ -20,19 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ComponentModel;
-using BH.oM.Base;
-using BH.Engine.Base;
+using System.Collections.Generic;
 using BH.oM.Reflection.Attributes;
-using BH.oM.LifeCycleAssessment;
-using BH.oM.Quantities.Attributes;
-using BH.Engine.Reflection;
 using BH.oM.LifeCycleAssessment.MaterialFragments;
-
+using BH.oM.Dimensional;
 using BH.Engine.Matter;
+using System.Linq;
 
 namespace BH.Engine.LifeCycleAssessment
 {
@@ -42,23 +36,45 @@ namespace BH.Engine.LifeCycleAssessment
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Query an Environmental Product Declaration MaterialFragment to return it's Density property value.")]
-        [Input("epd", "The EPD object to query.")]
-        [Output("density", "Density value queried from the EPD MaterialFragment.", typeof(Density))]
-        public static double GetFragmentDensity(this IEnvironmentalProductDeclarationData epd)
+        [Description("Query the QuantityTypeValue from any Environmental Product Declaration MaterialFragmment.")]
+        [Input("epd", "The EPD Object to query.")]
+        [Output("quantityTypeValue", "The quantityTypeValue property from the EPD.")]
+        public static double GetQuantityTypeValue(this IEnvironmentalProductDeclarationData epd)
         {
-            if (epd == null || epd.Density <= 0 || epd.Density == double.NaN)
+            if (epd == null)
             {
-                BH.Engine.Reflection.Compute.RecordWarning("The Environmental Product Declaration Material Fragment does not contain a valid density.");
-                return 0;
+                BH.Engine.Reflection.Compute.RecordWarning("The Environmental Product Declaration QuantityTypeValue could not be assessed. Returning default value of 1.");
+                return 1;
             }
             else
             {
-                object density = 0.0;
-                density = System.Convert.ToDouble(epd.PropertyValue("Density"));
+                double qtv = epd.QuantityTypeValue;
 
-                return System.Convert.ToDouble(density);
+                return qtv;
             }
         }
+
+        /***************************************************/
+
+        [Description("Query the QuantityTypeValue from any object with a valid construction with Environmental Product Declaration MaterialFragmments.")]
+        [Input("elementM", "The IElementM Object to query.")]
+        [Output("quantityTypeValue", "The quantityTypeValue property from the IElementM.")]
+        public static List<double> GetQuantityTypeValue(this IElementM elementM)
+        {
+            if (elementM == null)
+                return new List<double>();
+
+            List<double> qtv = elementM.IMaterialComposition().Materials.Select(x =>
+            {
+                var epd = x.Properties.Where(y => y is IEnvironmentalProductDeclarationData).FirstOrDefault() as IEnvironmentalProductDeclarationData;
+                if (epd != null)
+                    return epd.QuantityTypeValue;
+                return 1;
+            }).Where(x => x != null).ToList();
+
+            return qtv;
+        }
+
+        /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
Trying to clean up a few last-minute features to add prior to the feature freeze coming up. There may be some descriptions needing some attention so feel free to add a comment in your review 😄 

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
Construction assemblies can now be evaluated across compliant ElemenM objects with complete MaterialCompositions. Work has gone into providing helpful user feedback when attempting to Evaluate noncompliant objects (both by type and by EPD assignment as a material). 
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #150 
Closes #165 
Closes #166 
Closes #148 
Closes #127 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Compute Methods](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/LifeCycleAssessment_Toolkit/LifeCycleAssessment_Toolkit-%23150%20BulkMaterials.gh?csf=1&web=1&e=v2zwKR)
[QuantityTypeValue Tests](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/LifeCycleAssessment_Toolkit/LifeCycleAssessment_Toolkit-%23148%20QuantityTypeValue.gh?csf=1&web=1&e=BVbFQ0) 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Eval method returns note based on what EPD QuantityType is being used for calculation
- `GetFragmentQuantityType()` has been updated per compliance check
- All Eval methods have been updated to work with lists of values to allow for more complex buildups of materials via MaterialComposition
- GWP ResultCase now reflects the EPD field being queried instead of hard-coded to GWP
- `GetEvaluationValue()` now normalises each EPD metric being used based on the EPD's QuantityTypeValue 
- New `GetQuantityTypeValue()` 

### Additional comments
<!-- As required -->
FYI @al-fisher @IsakNaslundBh 