### PR TITLE
LCA_Toolkit: Updated EvaluateEPD method to handle mixed EPD quantity types

### DIFF
--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
@@ -67,7 +67,7 @@ namespace BH.Engine.LifeCycleAssessment
                 if (materialEPDs.Any(x => x.QuantityType == QuantityType.Mass))
                 {
                     double volumeOfMaterial = mc.Ratios[i] * volume;
-                    List<double> densityOfMassEpd = materialEPDs[0].GetEPDDensity();
+                    List<double> densityOfMassEpd = materialEPDs.Where(x => x.QuantityType == QuantityType.Mass).First().GetEPDDensity();
                     if (densityOfMassEpd == null || densityOfMassEpd.Count() == 0)
                     {
                         BH.Engine.Reflection.Compute.RecordError("Density could not be found. Add DensityFragment for all objects using Mass-based QuantityType EPDs.");

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
@@ -70,7 +70,7 @@ namespace BH.Engine.LifeCycleAssessment
                     List<double> densityOfMassEpd = materialEPDs[0].GetEPDDensity();
                     if (densityOfMassEpd == null || densityOfMassEpd.Count() == 0)
                     {
-                        BH.Engine.Reflection.Compute.RecordError("Density could not be found. Material density is required for all objects using Mass-based evaluations.");
+                        BH.Engine.Reflection.Compute.RecordError("Density could not be found. Add DensityFragment for all objects using Mass-based QuantityType EPDs.");
                         return null;
                     }
                     else


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Closes #239 

<!-- Add short description of what has been fixed -->
Fixes how EvaluateEnvironmentalProductDeclarationByMass handles cases with multiple EPDs of mixed quantity types. This allows EvaluteEnvironmentalProductDeclaration to be run for objects with multiple EPD types.


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/LifeCycleAssessment_Toolkit/%23239-EvaluateQuantitybyEPD?csf=1&web=1&e=1OoVog
