### PR TITLE
Remove conditional for epd values <= 0

### DIFF
--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByArea.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByArea.cs
@@ -64,7 +64,7 @@ namespace BH.Engine.LifeCycleAssessment
                         gwpByMaterial.Add(epdVal[x] * area);
                 }
 
-                if (epdVal == null || epdVal.Where(x => !double.IsNaN(x)).Sum() <= 0)
+                if (epdVal == null)
                 {
                     BH.Engine.Base.Compute.RecordError($"No value for {field} can be found within the supplied EPD.");
                     return null;

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByLength.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByLength.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.LifeCycleAssessment
                         gwpByMaterial.Add(epdVal[x] * length);
                 }
 
-                if (epdVal == null || epdVal.Where(x => !double.IsNaN(x)).Sum() <= 0)
+                if (epdVal == null)
                 {
                     BH.Engine.Base.Compute.RecordError($"No value for {field} can be found within the supplied EPD.");
                     return null;

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByMass.cs
@@ -54,7 +54,7 @@ namespace BH.Engine.LifeCycleAssessment
             List<Material> matList = materialComposition.Materials.ToList();
 
             List<double> epdVals = elementM.GetEvaluationValue(field, phases, QuantityType.Mass, materialComposition, exactMatch);
-            if (epdVals == null || epdVals.Where(x => !double.IsNaN(x)).Sum() <= 0)
+            if (epdVals == null)
             {
                 BH.Engine.Base.Compute.RecordError($"No value for {field} can be found within the supplied EPD.");
                 return null;

--- a/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByVolume.cs
+++ b/LifeCycleAssessment_Engine/Compute/EvaluateEnvironmentalProductDeclarationByVolume.cs
@@ -64,7 +64,7 @@ namespace BH.Engine.LifeCycleAssessment
                     gwpByMaterial.Add(epdVal[x] * volumeByRatio[x]);
             }
 
-            if (epdVal == null || epdVal.Where(x => !double.IsNaN(x)).Sum() <= 0)
+            if (epdVal == null)
             {
                 BH.Engine.Base.Compute.RecordError($"No value for {field} can be found within the supplied EPD.");
                 return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #162 

<!-- Add short description of what has been fixed -->
Removed the conditional that was catching EPD values <= 0 and throwing an error. Please check all 4 methods that were implementing this check. Mass, Area, Volume, and Length.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/LifeCycleAssessment_Toolkit/%23162-Fix%20GWP%20negative%20values/GWP%20negative%20value%20fix.gh?csf=1&web=1&e=tt733W

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->