### PR TITLE
ModifyInsulationEPD Method

### DIFF
--- a/LifeCycleAssessment_Engine/Modify/ModifyInsulationEPD.cs
+++ b/LifeCycleAssessment_Engine/Modify/ModifyInsulationEPD.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.Engine.Base;
+using BH.oM.Physical.FramingProperties;
+
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+using BH.oM.LifeCycleAssessment.MaterialFragments;
+using BH.oM.Quantities.Attributes;
+using System.Reflection;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Scales the quantity values in an area based insulation EPD based on project RSI (m2K/W).")]
+        [Input("insulationEPD", "Insulation EPD to scale quantity values for.")]
+        [Input("rSI", "RSI for insulation (m2K/W).")]
+        [Output("modifiedEPD", "FrameEdgeProperty with modified section profile depth.")]
+        public static EnvironmentalProductDeclaration ModifyInsulationEPD(this EnvironmentalProductDeclaration insulationEPD, double rSI)
+        {
+            if (rSI <= 0 || rSI == double.NaN)
+            {
+                Base.Compute.RecordError($"Valid RSI is not assigned.");
+                return null;
+            }
+
+            if (insulationEPD == null)
+            {
+                Base.Compute.RecordError($"Cannot convert null EPD.");
+                return null;
+            }
+
+            if (insulationEPD.QuantityType != oM.LifeCycleAssessment.QuantityType.Area)
+            {
+                Base.Compute.RecordError($"ModifyInsulationEPD only works on insulation EPDs with Area quantity type.");
+                return null;
+            }
+
+            foreach (EnvironmentalMetric environmentalMetric in insulationEPD.EnvironmentalMetrics)
+            {
+                foreach (PropertyInfo property in environmentalMetric.GetType().GetProperties().ToList())
+                {
+                    if (property.PropertyType == typeof(double))
+                        environmentalMetric.SetPropertyValue(property.Name, (double)property.GetValue(environmentalMetric) * rSI);
+                }
+            }
+
+            return insulationEPD;
+        }
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/Localisation_Toolkit/pull/113
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #317 

<!-- Add short description of what has been fixed -->
All US Insulation EPDs are area based EPDs assuming RSI = 1.0. The LCA calculation methods do not support calculations for these in cases where RSI does not = 1.0. This method creates a new area based EPD with the quantity value updated to reflect 1 m2 area with the project RSI value.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Facade_Engine/BHoM%20PR%20Test%20Files/240430_Insulation%20EPD%20Method%20Test%202.gh?csf=1&web=1&e=TagkGe