### PR TITLE
Onboard new CI checks (beta tier)

### DIFF
--- a/.github/workflows/ci-beta.yml
+++ b/.github/workflows/ci-beta.yml
@@ -1,0 +1,138 @@
+# Beta-tier proxy, BHoM variant. Bundles the tier's checks plus
+# copyright-compliance (BHoM enforces OSS copyright; the BHE variant omits it).
+# Copy to .github/workflows/ci-beta.yml in each BHoM beta repo.
+# Runs on pull_request, non-blocking until a ruleset requires its checks.
+# Workflow name CI keeps check contexts bare: required contexts are the job names.
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  ci-build:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 30
+    steps:
+      - name: Run build
+        uses: BHoM/CI_Toolkit/.github/actions/ci-build@develop
+        with:
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+
+  ci-code-compliance:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+    steps:
+      - name: Run code compliance
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
+        with:
+          check_type: code
+          patterns: '*.cs'
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+
+  ci-copyright-compliance:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+    steps:
+      - name: Run copyright compliance
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
+        with:
+          check_type: copyright
+          patterns: '*.cs'
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+
+  ci-dataset-compliance:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+    steps:
+      - name: Run dataset compliance
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
+        with:
+          check_type: dataset
+          patterns: ':(icase)*datasets*.json'
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+
+  ci-documentation-compliance:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+    steps:
+      - name: Run documentation compliance
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
+        with:
+          check_type: documentation
+          patterns: '*.cs'
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+
+  ci-project-compliance:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+    steps:
+      - name: Run project compliance
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
+        with:
+          check_type: project
+          patterns: '*AssemblyInfo.cs *.csproj'
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+
+  ci-dataset-tests:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 30
+    steps:
+      - name: Run dataset tests
+        uses: BHoM/CI_Toolkit/.github/actions/ci-dataset-tests@develop
+        with:
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+
+  ci-serialisation:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 90
+    steps:
+      - name: Run serialisation
+        uses: BHoM/CI_Toolkit/.github/actions/ci-serialisation@develop
+        with:
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+          base_ref: ${{ github.base_ref }}
+
+  ci-versioning:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 90
+    steps:
+      - name: Run versioning
+        uses: BHoM/CI_Toolkit/.github/actions/ci-versioning@develop
+        with:
+          app_id: ${{ secrets.BHOM_APP_ID }}
+          private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the beta-tier CI workflow as part of the new CI onboarding for sustainability-and-physics repositories.

The checks run on pull requests and are non-blocking during the evaluation period. On this PR they will pass within seconds since no code changes: the first code PR after merging exercises them fully.

Details and discussion: BuroHappoldEngineering/CI_Toolkit_Proxy#25
